### PR TITLE
hotfix: VRChat malformed OscValue variant

### DIFF
--- a/src/oscquery/models/node.rs
+++ b/src/oscquery/models/node.rs
@@ -546,6 +546,7 @@ pub enum OscValue {
     Bool(bool),
     Color(RgbaColorValue), // Changed from String to RgbaColorValue
     Array(Vec<OscValue>), // For OSC arrays.
+    Empty{}, // For VRChat (potential) bug
     Nil, // Represents OSC Nil. Serializes to JSON null.
 }
 


### PR DESCRIPTION
fixes: #2 

Hotfixです。VRChat側のバグとも言える(OSCQuery specに詳細な記述がない)ため、upstream bugとする場合はcloseしてください。