### PR TITLE
Fix to allow discovery of services on Unix systems

### DIFF
--- a/src/mdns/utils.rs
+++ b/src/mdns/utils.rs
@@ -11,7 +11,10 @@ use hickory_proto::{
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::net::UdpSocket;
 
+#[cfg(not(unix))]
 const MDNS_PORT: u16 = 5353;
+#[cfg(unix)]
+const MDNS_PORT: u16 = 0;
 /// TTL (Time to Live) for mDNS records in seconds.
 const RECORD_TTL: u32 = 120;
 


### PR DESCRIPTION
Small patch. This allows MDNS to discover services from Avahi on Unix/Linux systems allowing this crate to be able to find VRChat on Linux.

`cargo run --example full` is able to find VRChat and send messages over OSC